### PR TITLE
FIX: Removed Suspect User list Function and added Admin Upgrade

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -8,7 +8,7 @@ custom_tab_links:
 
 admin_only_tab_links:
   type: list
-  default: "user-secret, Suspect users, /admin/users/list/suspect|baby, New users, /admin/users/list/new"
+  default: "sync, Admin Upgrade, /admin/upgrade|baby, New users, /admin/users/list/new"
   description: "Add additional links in the format: icon, name, url"
 
 moderator_only_tab_links:


### PR DESCRIPTION
Suspect user list does not exist anymore.

https://meta.discourse.org/t/custom-user-menu-tab/130091/3