### PR TITLE
DEV: adds group filter in custom_tab_links setting

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -8,8 +8,9 @@
       const seg = $.map(i.split(","), $.trim),
       icon = seg[0],
       content = seg[1],
-      href = seg[2];
-      return { icon: icon, content: content, href: href };
+      href = seg[2],
+      groups = seg[3] ? $.map(seg[3].split("-"), $.trim) : null;
+      return { icon: icon, content: content, href: href, groups: groups };
     });
   }
 
@@ -32,6 +33,7 @@
   });
 
   const QuickAccessPanel = queryRegistry("quick-access-panel");
+  const currentUser = api.getCurrentUser();
 
   if (QuickAccessPanel) {
     createWidgetFrom(QuickAccessPanel, "quick-access-custom", {
@@ -53,10 +55,15 @@
 
       _getItems() {
         const items = [];
+        const currentUserGroups = currentUser.groups.map(x => x["name"]);
 
         if (this._getDefaultItems()) {
           this._getDefaultItems().forEach(button => {
             if (button.content != undefined) {
+              if (!currentUser.admin && button.groups && !currentUserGroups.some(r=> button.groups.includes(r))) {
+                return;
+              }
+
               items.push(button);
             }
           });

--- a/settings.yml
+++ b/settings.yml
@@ -3,8 +3,8 @@ custom_tab_icon:
 
 custom_tab_links:
   type: list
-  default: "paint-brush, Forum appearance, /my/preferences/interface |bell-slash, Muted topics, /latest?state=muted"
-  description: "Add additional links in the format: icon, name, url"
+  default: "paint-brush, Forum appearance, /my/preferences/interface |bell-slash, Muted topics, /latest?state=muted, group1-group-2-group3"
+  description: "Add additional links in the format: icon, name, url, group1-group2-group3"
 
 admin_only_tab_links:
   type: list


### PR DESCRIPTION
In this PR I have allowed a parameter in `custom_tab_links` where users can enter a list of groups.
The link will be displayed to all admins & users in the specified groups.